### PR TITLE
Add basic copy operation.

### DIFF
--- a/patch/copy_op.go
+++ b/patch/copy_op.go
@@ -1,0 +1,15 @@
+package patch
+
+type CopyOp struct {
+	Path Pointer
+	From Pointer
+}
+
+func (op CopyOp) Apply(doc interface{}) (interface{}, error) {
+	value, err := FindOp{Path: op.From}.Apply(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return ReplaceOp{Path: op.Path, Value: value}.Apply(doc)
+}

--- a/patch/copy_op_test.go
+++ b/patch/copy_op_test.go
@@ -1,0 +1,41 @@
+package patch_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cppforlife/go-patch/patch"
+)
+
+var _ = Describe("CopyOp.Apply", func() {
+	Describe("array item", func() {
+		It("replaces array item", func() {
+			res, err := CopyOp{
+				Path: MustNewPointerFromString("/-"),
+				From: MustNewPointerFromString("/0"),
+			}.Apply([]interface{}{1, 2, 3})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal([]interface{}{1, 2, 3, 1}))
+		})
+	})
+
+	Describe("map key", func() {
+		It("copies map key", func() {
+			doc := map[interface{}]interface{}{
+				"abc": "abc",
+				"xyz": "xyz",
+			}
+
+			res, err := CopyOp{
+				From: MustNewPointerFromString("/abc"),
+				Path: MustNewPointerFromString("/def?"),
+			}.Apply(doc)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(map[interface{}]interface{}{
+				"abc": "abc",
+				"def": "abc",
+				"xyz": "xyz",
+			}))
+		})
+	})
+})


### PR DESCRIPTION
Based on suggestions in #5, this implements a very simple copy operation by combining existing find and replace operations. We can talk about adding more options, like sub-operations to be applied before copying, but I think this is a reasonable place to start.

cc @cppforlife @dsabeti @dpb587-pivotal @anEXPer